### PR TITLE
Fix npm install for --only=prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
     "postinstall": "node_modules/.bin/electron-rebuild -e ../../node_modules/electron"
   },
   "dependencies": {
-    "onoff": "latest"
-  },
-  "devDependencies": {
+    "onoff": "latest",
     "electron-rebuild": "^1.2.1"
   }
 }


### PR DESCRIPTION
- Move electron-rebuild from devDependencies to dependencies
- Fixes #45 