### PR TITLE
Add notification before switching screen off

### DIFF
--- a/MMM-PIR-Sensor.js
+++ b/MMM-PIR-Sensor.js
@@ -7,6 +7,7 @@
  * MIT Licensed.
  */
 
+
 Module.register('MMM-PIR-Sensor',{
 
 	requiresVersion: "2.1.0",
@@ -18,12 +19,17 @@ Module.register('MMM-PIR-Sensor',{
 		relayOnState: 1,
 		powerSaving: true,
 		powerSavingDelay: 0,
+		powerSavingNotification: false,
+		powerSavingMessage: "Monitor will be turn Off by PIR module", 
 	},
 
 	// Override socket notification handler.
 	socketNotificationReceived: function(notification, payload) {
 		if (notification === "USER_PRESENCE"){
 			this.sendNotification(notification, payload)
+		        if (payload === false && this.config.powerSavingNotification === true){
+				this.sendNotification("SHOW_ALERT",{type:"notification", message:this.config.powerSavingMessage});
+			}
 		}
 	},
 

--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ The following properties can be configured:
 			<td>To display a notification before to switch screen off<br>
 				<br><b>Possible values:</b> <code>boolean</code>
 				<br><b>Default value:</b> <code>false</code>
+				<br><b>Note:</b> Need the default module "alert" to be declared on config.js file.
 			</td>
 		</tr>
 		<tr>
 			<td><code>powerSavingMessage</code></td>
 			<td>Message notification to display before to switch screen off<br>
-				<br><b>Possible values:</b> <code>string</code>
 				<br><b>Default value:</b> <code>"Monitor will be turn Off by PIR module"</code>
 			</td>
 		</tr>

--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ The following properties can be configured:
 				<br><b>Default value:</b> <code>1</code>
 			</td>
 		</tr>
+		<tr>
+			<td><code>powerSavingNotification</code></td>
+			<td>To display a notification before to switch screen off<br>
+				<br><b>Possible values:</b> <code>boolean</code>
+				<br><b>Default value:</b> <code>false</code>
+			</td>
+		</tr>
+		<tr>
+			<td><code>powerSavingMessage</code></td>
+			<td>Message notification to display before to switch screen off<br>
+				<br><b>Possible values:</b> <code>string</code>
+				<br><b>Default value:</b> <code>"Monitor will be turn Off by PIR module"</code>
+			</td>
+		</tr>
 	</tbody>
 </table>
 


### PR DESCRIPTION
Small update proposal to allow to display a notification when the PIR sensor don't see anymore any movement. This allow the Mirror user to react during the timer defined on the config file to re-activate the module before it switch the screen off. 
This is a simple message notification using "alert" default module, the remaining value of the timer will not be displayed. 