### PR TITLE
 Bug correction on some start-up situation

### DIFF
--- a/MMM-PIR-Sensor.js
+++ b/MMM-PIR-Sensor.js
@@ -28,11 +28,11 @@ Module.register('MMM-PIR-Sensor',{
 	socketNotificationReceived: function (notification, payload) {
 		if (notification === 'USER_PRESENCE') {
 			this.sendNotification(notification, payload)
-		} else if (notification === 'SHOW_ALERT') {
-			this.sendNotification(notification, payload)
-		        if (payload === false && this.config.powerSavingNotification === true){
+			if (payload === false && this.config.powerSavingNotification === true){
 				this.sendNotification("SHOW_ALERT",{type:"notification", message:this.config.powerSavingMessage});
 			}
+		} else if (notification === 'SHOW_ALERT') {
+			this.sendNotification(notification, payload)
 		}
 	},
 

--- a/MMM-PIR-Sensor.js
+++ b/MMM-PIR-Sensor.js
@@ -45,5 +45,7 @@ Module.register('MMM-PIR-Sensor',{
 	start: function () {
 		this.sendSocketNotification('CONFIG', this.config);
 		Log.info('Starting module: ' + this.name);
+		this.sendSocketNotification('SCREEN_WAKEUP', null); //to start the screen at start-up, in case it was off before (otherwise it was staying off...)
+
 	}
 });


### PR DESCRIPTION
In case the Mirror has been restarted during hdmi screen off (example : restart due to new config.js file or restart requested by Remote-Control), the screen stays Off and the PIR-Sensor couldn't wake it up again. It was necessary to ask Remote-Control to switch the screen On again before PIR-Sensor could work correctly again. 

To correct this issue, I propose to request as 'SCREEN_WAKEUP' on start function. As the node_helper "activateMonitor" function will check if the screen is already wakeup before to ask the hdmi output on, it has no impact on other situations.