### PR TITLE
delay functionality when switching both, via HDMI and a relay

### DIFF
--- a/MMM-PIR-Sensor.js
+++ b/MMM-PIR-Sensor.js
@@ -13,6 +13,7 @@ Module.register('MMM-PIR-Sensor',{
 		sensorPin: 22,
 		sensorState: 1,
 		relayPin: false,
+		switchHDMI: true,
 		relayState: 1,
 		alwaysOnPin: false,
 		alwaysOnState: 1,

--- a/MMM-PIR-Sensor.js
+++ b/MMM-PIR-Sensor.js
@@ -14,6 +14,8 @@ Module.register('MMM-PIR-Sensor',{
 		sensorState: 1,
 		relayPin: false,
 		switchHDMI: true,
+		relayOnDelay: 0,
+		hdmiOffDelay: 0,
 		relayState: 1,
 		alwaysOnPin: false,
 		alwaysOnState: 1,

--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ The following properties can be configured:
 			</td>
 		</tr>
 		<tr>
+			<td><code>relayOnDelay</code></td>
+			<td>Delay before switching on the relay after motion was detected.<br>
+				<br><b>Possible values:</b> <code>int (ms)</code>
+				<br><b>Default value:</b> <code>0</code>
+			</td>
+		</tr>
+		<tr>
+			<td><code>hdmiOffDelay</code></td>
+			<td>Delay before switching off the monitor via HDMI after no motion was detected.<br>
+				<br><b>Possible values:</b> <code>int (ms)</code>
+				<br><b>Default value:</b> <code>0</code>
+			</td>
+		</tr>
+		<tr>
 			<td><code>relayState</code></td>
 			<td>GPIO-state your relay is turned on.<br>
 				<br><b>Possible values:</b> <code>int (0 or 1)</code>

--- a/README.md
+++ b/README.md
@@ -66,10 +66,17 @@ The following properties can be configured:
 		</tr>
 		<tr>
 			<td><code>relayPin</code></td>
-			<td>If you want to use a relay to turn of the mirror provide the pin here. If no pin is provided HDMI is turned off instead.<br>
+			<td>If you want to use a relay to turn of the mirror provide the pin here.<br>
 				<br><b>Possible values:</b> <code>int</code>
 				<br><b>Default value:</b> <code>false</code>
 				<br><b>Note:</b> Please use BCM-numbering.
+			</td>
+		</tr>
+		<tr>
+			<td><code>switchHDMI</code></td>
+			<td>If you want to use HDMI to turn the monitor on and off.<br>
+				<br><b>Possible values:</b> <code>boolean</code>
+				<br><b>Default value:</b> <code>true</code>
 			</td>
 		</tr>
 		<tr>

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The following properties can be configured:
 		</tr>
 		<tr>
 			<td><code>relayOnDelay</code></td>
-			<td>Delay before switching on the relay after motion was detected.<br>
+			<td>Delay before switching on the relay after motion was detected. This delay is only applied when the monitor was switched off via HDMI before.<br>
 				<br><b>Possible values:</b> <code>int (ms)</code>
 				<br><b>Default value:</b> <code>0</code>
 			</td>

--- a/node_helper.js
+++ b/node_helper.js
@@ -26,7 +26,8 @@ module.exports = NodeHelper.create({
         if (this.config.relayPin !== false) {
             this.relay.writeSync(this.config.relayState);
         }
-        else if (this.config.relayPin === false) {
+        
+        if (this.config.switchHDMI === true) {
             // Check if hdmi output is already on
             exec("/usr/bin/vcgencmd display_power").stdout.on('data', function(data) {
                 if (data.indexOf("display_power=0") === 0)
@@ -46,7 +47,8 @@ module.exports = NodeHelper.create({
         if (this.config.relayPin !== false) {
             this.relay.writeSync((this.config.relayState + 1) % 2);
         }
-        else if (this.config.relayPin === false) {
+        
+        if (this.config.switchHDMI === true) {
             exec("/usr/bin/vcgencmd display_power 0", null);
         }
     },

--- a/node_helper.js
+++ b/node_helper.js
@@ -29,6 +29,7 @@ module.exports = NodeHelper.create({
             // cancle any scheduled off events
             if(self.hdmiOffTimeout !== undefined) {
                 clearTimeout(self.hdmiOffTimeout);
+                self.hdmiOffTimeout = undefined;
             }
             
             // Check if hdmi output is already on
@@ -68,6 +69,7 @@ module.exports = NodeHelper.create({
             // cancel any scheduled turn-on events
             if(self.relayOnTimeout !== undefined) {
                 clearTimeout(self.relayOnTimeout);
+                self.relayOnTimeout = undefined;
             }
 
             self.relay.writeSync((self.config.relayState + 1) % 2);

--- a/node_helper.js
+++ b/node_helper.js
@@ -17,27 +17,28 @@ module.exports = NodeHelper.create({
     },
 
     activateMonitor: function () {
+        let self = this;
         // If always-off is enabled, keep monitor deactivated
-        let alwaysOffTrigger = this.alwaysOff && (this.alwaysOff.readSync() === this.config.alwaysOffState)
+        let alwaysOffTrigger = self.alwaysOff && (self.alwaysOff.readSync() === self.config.alwaysOffState)
         if (alwaysOffTrigger) {
             return;
         }
 
         // If relays are being used
-        if (this.config.relayPin !== false) {
+        if (self.config.relayPin !== false) {
             // check if a switch on is already scheduled
-            if(this.relayOnTimeout === undefined) {
-                this.relayOnTimeout = setTimeout(function() {
-                    this.relay.writeSync(this.config.relayState);
-                    this.relayOnTimeout = undefined;
-                }, this.config.relayOnDelay);
+            if(self.relayOnTimeout === undefined) {
+                self.relayOnTimeout = setTimeout(function() {
+                    self.relay.writeSync(self.config.relayState);
+                    self.relayOnTimeout = undefined;
+                }, self.config.relayOnDelay);
             }
         }
         
-        if (this.config.switchHDMI === true) {
+        if (self.config.switchHDMI === true) {
             // cancle any scheduled off events
-            if(this.hdmiOffTimeout !== undefined) {
-                clearTimeout(this.hdmiOffTimeout);
+            if(self.hdmiOffTimeout !== undefined) {
+                clearTimeout(self.hdmiOffTimeout);
             }
             // Check if hdmi output is already on
             exec("/usr/bin/vcgencmd display_power").stdout.on('data', function(data) {
@@ -48,29 +49,30 @@ module.exports = NodeHelper.create({
     },
 
     deactivateMonitor: function () {
+        let self = this;
         // If always-on is enabled, keep monitor activated
-        let alwaysOnTrigger = this.alwaysOn && (this.alwaysOn.readSync() === this.config.alwaysOnState)
-        let alwaysOffTrigger = this.alwaysOff && (this.alwaysOff.readSync() === this.config.alwaysOffState)
+        let alwaysOnTrigger = self.alwaysOn && (self.alwaysOn.readSync() === self.config.alwaysOnState)
+        let alwaysOffTrigger = self.alwaysOff && (self.alwaysOff.readSync() === self.config.alwaysOffState)
         if (alwaysOnTrigger && !alwaysOffTrigger) {
             return;
         }
         // If relays are being used in place of HDMI
-        if (this.config.relayPin !== false) {
+        if (self.config.relayPin !== false) {
             // cancel any scheduled turn-on events
-            if(this.relayOnTimeout !== undefined) {
-                clearTimeout(this.relayOnTimeout);
+            if(self.relayOnTimeout !== undefined) {
+                clearTimeout(self.relayOnTimeout);
             }
 
-            this.relay.writeSync((this.config.relayState + 1) % 2);
+            self.relay.writeSync((self.config.relayState + 1) % 2);
         }
 
-        if (this.config.switchHDMI === true) {
+        if (self.config.switchHDMI === true) {
             // check if a switch off is already scheduled
-            if(this.hdmiOffTimeout === undefined) {
-                this.hdmiOffTimeout = setTimeout(function() {
+            if(self.hdmiOffTimeout === undefined) {
+                self.hdmiOffTimeout = setTimeout(function() {
                     exec("/usr/bin/vcgencmd display_power 0", null);
-                    this.hdmiOffTimeout = undefined;
-                }, this.config.hdmiOffDelay);
+                    self.hdmiOffTimeout = undefined;
+                }, self.config.hdmiOffDelay);
             }
         }
     },


### PR DESCRIPTION
Hi, 
for my personal MM Project I use a control line on the display to control the backlight of the display. This has the benefit of being very fast, as the display controller does not need to boot after switching on. However, to save power, I also want to switch of the controller if the display is off for a longer time, which is easiest over the HDMI control. 

I thus added the the config option ```switchhHDMI``` to allow setting a relayPin in the configuration without disabling the HDMI switching and ```hdmiOffDelay``` to control the delay before powering off the controller via HDMI after switching off only the backlight (over a relay). 

However, this causes the display to show solid white backfill if the display backlight (e.g. relay) is switched on before the controller is booted back up. I thus also added the ```relayOnDelay``` configuration option to delay the switching of the relay if motion is detected AND the display was switched off over HDMI, otherwise the backlight switches instantly. 

With these changes I'm able to benefit of the fast switching when motion is detected with short delays and only need to wait until the controller started up once no motion was detected for e.g. 30 minutes.

I documented the new configuration options in the readme and also set the default values to leave the behaviour unchanged when people upgrade the module. Maybe this is useful for others. 