### PR TITLE
New Feature: Time Range for activate the screen

### DIFF
--- a/MMM-PIR-Sensor.js
+++ b/MMM-PIR-Sensor.js
@@ -22,6 +22,8 @@ Module.register('MMM-PIR-Sensor',{
 		powerSavingDelay: 0,
 		powerSavingNotification: false,
 		powerSavingMessage: "Monitor will be turn Off by PIR module", 
+                notBeforeHour: null,
+                notAfterHour:  null
 	},
 
 	// Override socket notification handler.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,22 @@ The following properties can be configured:
 				<br><b>Default value:</b> <code>"Monitor will be turn Off by PIR module"</code>
 			</td>
 		</tr>
+                <tr>
+                        <td><code>notBeforeHour</code></td>
+                        <td>Time duration, before the screen should be stay turned off.<br>
+                                <br><b>Possible values:</b> <code>0-23</code>
+                                <br><b>Default value:</b> <code>null</code>
+                                <br><b>Note:</b>Useful if the screen only should turn on between an timerange. Must set with <code>notAfterHour</code> 
+                        </td>
+                </tr>
+                <tr>
+                        <td><code>notAfterHour</code></td>
+                        <td>Time duration, after the screen should be stay turned off.<br>
+                                <br><b>Possible values:</b> <code>0-23</code>
+                                <br><b>Default value:</b> <code>null</code>
+                                br><b>Note:</b>Useful if the screen only should turn on between an timerange. Must set with <code>notAfterHour</code>
+                        </td>
+                </tr>
 	</tbody>
 </table>
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -18,10 +18,10 @@ module.exports = NodeHelper.create({
 
     activateMonitor: function () {
         // If always-off is enabled, keep monitor deactivated
-        d = new Date();
-        h = d.getHours();
-        if(this.config.notAfterHour !== null && this.config.notBeforeHour !== null && (h >= this.config.notAfterHour || h <= this.config.notBeforeHour)){
-           return;
+        this.d = new Date();
+        this.h = this.d.getHours();
+        if(this.config.notAfterHour !== null && this.config.notBeforeHour !== null && (this.h >= this.config.notAfterHour || this.h <= this.config.notBeforeHour)){
+            return;
         }
         let alwaysOffTrigger = this.alwaysOff && (this.alwaysOff.readSync() === this.config.alwaysOffState)
         if (alwaysOffTrigger) {

--- a/node_helper.js
+++ b/node_helper.js
@@ -18,6 +18,11 @@ module.exports = NodeHelper.create({
 
     activateMonitor: function () {
         // If always-off is enabled, keep monitor deactivated
+        d = new Date();
+        h = d.getHours();
+        if(this.config.notAfterHour !== null && this.config.notBeforeHour !== null && (h >= this.config.notAfterHour || h <= this.config.notBeforeHour)){
+           return;
+        }
         let alwaysOffTrigger = this.alwaysOff && (this.alwaysOff.readSync() === this.config.alwaysOffState)
         if (alwaysOffTrigger) {
             return;


### PR DESCRIPTION
This is useful, if you dont want, that the screen turn on in the night for example.
If the screen should stay turned off between 20-08 o'clock, you can configure the follow:
```
        {
                 module: 'MMM-PIR-Sensor',
                 config: {
                         // See 'Configuration options' for more information.
                         sensorPin: 22,
                         powerSavingDelay: 10,
                         notAfterHour: 20,
                         notBeforeHour: 6
                 }
         }
```