### PR TITLE
fix SCREEN_WAKEUP behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-.idea
-node_modules
+.*.swp
+package-lock.json
+node_modules/

--- a/MMM-PIR-Sensor.js
+++ b/MMM-PIR-Sensor.js
@@ -38,7 +38,7 @@ Module.register('MMM-PIR-Sensor',{
 
 	notificationReceived: function (notification, payload) {
 		if (notification === 'SCREEN_WAKEUP') {
-			this.sendNotification(notification, payload)
+			this.sendSocketNotification(notification, payload)
 		}
 	},
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -77,7 +77,7 @@ module.exports = NodeHelper.create({
                             timer: 4000
                         });
                         if (self.config.powerSaving){
-                            clearTimeout(self.deactivateMonitorTimeout);
+                            self.clearMonitorTimeout();
                         }
                     } else if (value === (alwaysOnState + 1) % 2) {
                         self.sendSocketNotification('ALWAYS_ON', false);
@@ -102,7 +102,7 @@ module.exports = NodeHelper.create({
                         self.sendSocketNotification('ALWAYS_OFF', false);
                         self.activateMonitor();
                         if (self.config.powerSaving){
-                            clearTimeout(self.deactivateMonitorTimeout);
+                            self.clearMonitorTimeout();
                         }
                     }
                 })
@@ -120,7 +120,7 @@ module.exports = NodeHelper.create({
                 if (value == valueOn) {
                     self.sendSocketNotification('USER_PRESENCE', true);
                     if (self.config.powerSaving){
-                        clearTimeout(self.deactivateMonitorTimeout);
+                        self.clearMonitorTimeout();
                         self.activateMonitor();
                     }
                 }
@@ -130,17 +130,28 @@ module.exports = NodeHelper.create({
                         return;
                     }
 
-                    self.deactivateMonitorTimeout = setTimeout(function() {
-                        self.deactivateMonitor();
-                    }, self.config.powerSavingDelay * 1000);
+                    self.setMonitorTimeout();
                 }
             });
 
             this.started = true;
 
         } else if (notification === 'SCREEN_WAKEUP') {
+            console.log('MMM-PIR-Sensor node_helper: SCREEN_WAKEUP notification received');
             this.activateMonitor();
+            this.setMonitorTimeout();
         }
+    },
+    clearMonitorTimeout: function() {
+        console.log('MMM-PIR-Sensor: clearing monitor timeout if set');
+        if (this.deactivateMonitorTimeout) {
+            clearTimeout(this.deactivateMonitorTimeout);
+        }
+    },
+    setMonitorTimeout: function() {
+        const timeout = this.config.powerSavingDelay * 1000;
+        console.log('MMM-PIR-Sensor: setting monitor timeout to ' + timeout);
+        this.deactivateMonitorTimeout = setTimeout(this.deactivateMonitor, timeout);
     }
 
 });


### PR DESCRIPTION
There were two issues.

First: in my case, the `SCREEN_WAKEUP` socket notification was being sent from `node_helper.js` of another module. The browser code in `MMM-PIR-Sensor.js` would receive this notification and relay it using the `sendNotification` function. However, the handler on the server-side in `node_helper.js` would not see it since it is only responding to notifications sent via `sendSocketNotification`.

Second: after the screen was woken up, it would never go back to sleep unless the PIR sensor reported some movement followed by no movement.