### PR TITLE
Support preventHDMITimeout + recover well from crash or power failure + CEC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ The following properties can be configured:
                                 br><b>Note:</b>Useful if the screen only should turn on between an timerange. Must set with <code>notAfterHour</code>
                         </td>
                 </tr>
+                <tr>
+			<td><code>preventHDMITimeout</code></td>
+			<td>Time, in minutes, after which- while HDMI is off- the screen will be briefly turned on and off again, periodically. This is to avoid older HDMI screens from automatically turning Off due to "No Signal".
+			<br><b>Possible values:</b> <code>0-10</code>
+			<br><b>Default value:</b> <code>0</code>
+			<br><b>Note:</b>0 value means that this feature is turned off.
+			</td>
+		</tr>    
 	</tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -141,10 +141,17 @@ The following properties can be configured:
                 </tr>
                 <tr>
 			<td><code>preventHDMITimeout</code></td>
-			<td>Time, in minutes, after which- while HDMI is off- the screen will be briefly turned on and off again, periodically. This is to avoid older HDMI screens from automatically turning Off due to "No Signal".
-			<br><b>Possible values:</b> <code>0-10</code>
-			<br><b>Default value:</b> <code>0</code>
-			<br><b>Note:</b>0 value means that this feature is turned off.
+			<td>When <code>powerSaving</code> is On: time, in minutes, after which- while HDMI is off- the screen will be briefly turned on and off again, periodically. This is to avoid older HDMI screens from automatically turning Off due to "No Signal".
+				<br><b>Possible values:</b> <code>0-10</code>
+				<br><b>Default value:</b> <code>0</code>
+				<br><b>Note:</b>0 value means that this feature is turned off.
+			</td>
+		</tr>    
+               <tr>
+			<td><code>supportCEC</code></td>
+		        <td>When <code>powerSaving</code> is On: support CEC to turn monitor ON or OFF as well, not just the HDMI circuit in the RPI.
+				<br><b>Possible values:</b> <code>boolean</code>
+				<br><b>Default value:</b> <code>false</code>
 			</td>
 		</tr>    
 	</tbody>


### PR DESCRIPTION
- Support preventHDMITimeout to re-wake HDMI briefly every predefined minutes, that's to avoid old screen timeout due to No Signal (I have that a lot..). 

- Setting up the power saving timeout even if motion was not initially detected, to have power saving even if the application started with no one in front of the PIR (such as- after power failure).
- Turning HDMI On at startup, if not AlwaysOff, to recover well from crash or application close while HDMI is off.

- Support CEC ("supportCEC" in config) to turn monitor/TV On and Off