### PR TITLE
Fix readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This an extension for the [MagicMirror](https://github.com/MichMich/MagicMirror)
 1. Navigate into your MagicMirror's `modules` folder and execute `git clone https://github.com/paviro/MMM-PIR-Sensor.git`. A new folder will appear navigate into it.
 2. Execute `npm install` to install the node dependencies.
 3. Add your user (`pi`?) to the `gpio group` by executing `sudo usermod -a -G gpio pi`.
-4. Execute `sudo chmod u+s /opt/vc/bin/tvservice && sudo chmod u+s /bin/chvt` to allow turning on/off the hdmi output.
+4. Execute `sudo chmod u+s /usr/bin/vcgencmd && sudo chmod u+s /bin/chvt` to allow turning on/off the hdmi output.
 5. Reboot your Pi.
 
 ## Using the module


### PR DESCRIPTION
Thank you for the excellent straightforward working module.

I believe there is an error in instructions, as they refer to changing permissions for `tvservice` when the module actually uses `vcgencmd` for monitor control. I think older versions of this module probably used `tvservice` but there is no longer any reference or use of `tvservice` in it currently.

TBH, however, I'm not sure if `vcgencmd` even needs the same permission modifications to be called, but this would clear up confusions.

This change would probably address issue #123  