### PR TITLE
purpose magicmirror-rebuild for working with MM v2.18.x and more

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Magic-Mirror-Module-PIR-Sensor",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "PIR motion sensor module for the Magic Mirror.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
   },
   "homepage": "https://github.com/paviro/MMM-PIR-Sensor#readme",
   "scripts": {
-    "postinstall": "node_modules/.bin/electron-rebuild -e ../../node_modules/electron"
+    "postinstall": "node_modules/.bin/MagicMirror-rebuild -e ../../node_modules/electron"
   },
   "dependencies": {
     "onoff": "latest",
-    "electron-rebuild": "^1.2.1"
+    "magicmirror-rebuild": "^1.0.4"
   }
 }


### PR DESCRIPTION
Hi @paviro,
 
Actually electron rebuild not works with MMv2.18.x

I purpose my own working version and verified in [MM forum topic](https://forum.magicmirror.builders/topic/16074/electron-rebuild-and-magicmirror-v2-18-and-more)

@bugsounet